### PR TITLE
feat: add hoodi, increase accounts to 30

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -39,15 +39,15 @@ jobs:
           build-args: |
             HH_CONFIG=hardhat.config.mainnet-fork.ts
 
-      - name: Build and push holesky fork image
+      - name: Build and push hoodi fork image
         uses: docker/build-push-action@v6.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/lidofinance/hardhat-node:${{ github.ref_name }}-holesky-fork
+          tags: ghcr.io/lidofinance/hardhat-node:${{ github.ref_name }}-hoodi-fork
           build-args: |
-            HH_CONFIG=hardhat.config.holesky-fork.ts
+            HH_CONFIG=hardhat.config.hoodi-fork.ts
 
       - name: Build and push mainnet scratch image
         uses: docker/build-push-action@v6.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 ARG NODE_VERSION=lts
 FROM node:${NODE_VERSION}-alpine
 
-ARG PNPM_VERSION=9.11.0
+ARG PNPM_VERSION=10.8.0
 ARG HH_CONFIG="hardhat.config.mainnet-fork.ts"
 
 # Use production node environment by default.

--- a/README.md
+++ b/README.md
@@ -9,25 +9,35 @@ To run the mainnet fork you have to set one of the following environment variabl
 - `ETH_RPC_URL` to use a custom provider
 
 ### Examples
+
 With Infura
+
 ```bash
-docker run -e INFURA_TOKEN=your_token -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.22.18.1
+docker run -e INFURA_TOKEN=your_token -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.23.0
 ```
+
 With Alchemy:
+
 ```bash
-docker  run -e ALCHEMY_TOKEN=your_token -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.22.18.1
+docker  run -e ALCHEMY_TOKEN=your_token -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.23.0
 ```
+
 With custom provider:
+
 ```bash
-docker run -e ETH_RPC_URL=your_url -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.22.18.1
+docker run -e ETH_RPC_URL=your_url -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.23.0
 ```
+
 If you don't need to fork mainnet, and you only want to work with the `-scratch` node:
+
 ```bash
-docker run -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.22.18.1-scratch
+docker run -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.23.0
 ```
-If you don't need testing ant holesky use `-holesky-fork` node, for example:
+
+If you don't need testing ant hoodi use `-hoodi-fork` node, for example:
+
 ```bash
-docker run -e ETH_RPC_URL=your_url -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.22.18.1-holesky-fork
+docker run -e ETH_RPC_URL=your_url -p 8545:8545 -it --rm ghcr.io/lidofinance/hardhat-node:2.22.18.1-hoodi-fork
 ```
 
 ### Forking fork chainId issue

--- a/hardhat.config.hoodi-fork.ts
+++ b/hardhat.config.hoodi-fork.ts
@@ -4,18 +4,17 @@ import "@nomicfoundation/hardhat-ethers";
 
 import networks from "./src/networks";
 
-
 const config: HardhatUserConfig = {
-  solidity: "0.8.23",
+  solidity: "0.8.25",
   networks: {
     hardhat: {
-      ...networks.maybeChainIdConfig(17000),
+      ...networks.maybeChainIdConfig(560048),
       initialBaseFeePerGas: 0,
       accounts: {
-        count: 10,
+        count: 30,
       },
       forking: {
-        url: networks.rpcUrl("eth", "holesky"),
+        url: networks.rpcUrl("eth", "hoodi"),
       },
     },
   },

--- a/hardhat.config.mainnet-fork-shanghai.ts
+++ b/hardhat.config.mainnet-fork-shanghai.ts
@@ -4,16 +4,15 @@ import "@nomicfoundation/hardhat-ethers";
 
 import networks from "./src/networks";
 
-
 const config: HardhatUserConfig = {
-  solidity: "0.8.23",
+  solidity: "0.8.25",
   networks: {
     hardhat: {
       ...networks.maybeChainIdConfig(1),
       hardfork: "shanghai",
       initialBaseFeePerGas: 0,
       accounts: {
-        count: 10,
+        count: 30,
       },
       forking: {
         url: networks.rpcUrl("eth", "mainnet"),

--- a/hardhat.config.mainnet-fork.ts
+++ b/hardhat.config.mainnet-fork.ts
@@ -4,15 +4,14 @@ import "@nomicfoundation/hardhat-ethers";
 
 import networks from "./src/networks";
 
-
 const config: HardhatUserConfig = {
-  solidity: "0.8.23",
+  solidity: "0.8.25",
   networks: {
     hardhat: {
       ...networks.maybeChainIdConfig(1),
       initialBaseFeePerGas: 0,
       accounts: {
-        count: 10,
+        count: 30,
       },
       forking: {
         url: networks.rpcUrl("eth", "mainnet"),

--- a/hardhat.config.mainnet-scratch.ts
+++ b/hardhat.config.mainnet-scratch.ts
@@ -4,13 +4,13 @@ import "@nomicfoundation/hardhat-ethers";
 import networks from "./src/networks";
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.23",
+  solidity: "0.8.25",
   networks: {
     hardhat: {
       ...networks.maybeChainIdConfig(1),
       initialBaseFeePerGas: 0,
       accounts: {
-        count: 10,
+        count: 30,
       },
     },
   },

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -1,7 +1,7 @@
 import env from "./env";
 
 export type ChainName = "eth" | "arb" | "opt";
-export type NetworkName = "mainnet" | "holesky";
+export type NetworkName = "mainnet" | "hoodi";
 
 /**
  * Returns the RPC url for the given network name
@@ -13,8 +13,7 @@ function url(chainName: ChainName, networkName: NetworkName): string {
     alchemyUrl(chainName, networkName);
   if (!url) {
     throw new Error(
-      "RPC node credential was not provided. Please, set one of " +
-        "RPC_URL, INFURA_TOKEN or ALCHEMY_TOKEN env variables",
+      "RPC node credential was not provided. Please, set one of RPC_URL, INFURA_TOKEN or ALCHEMY_TOKEN env variables"
     );
   }
   return url;
@@ -28,7 +27,7 @@ function rpcUrl(chainName: ChainName) {
 
 function maybeChainIdConfig(chainId: number) {
   if (env.DONT_SET_CHAIN_ID()) {
-    return { };
+    return {};
   }
   return { chainId };
 }


### PR DESCRIPTION
This pull request includes several changes to update configurations and dependencies, as well as renaming a network fork. The most important changes include renaming the `holesky` fork to `hoodi`, updating the PNPM version, and modifying the Solidity version and network configurations.

### Network Fork Renaming:
* [`.github/workflows/build_and_push_image.yml`](diffhunk://#diff-baa7a90659f5a10fe3fc321a50dfb5d4ab52b8e67d9594de8cb83d4f5943680fL42-R50): Renamed `holesky` fork to `hoodi` in the Docker build and push steps.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R40): Updated references from `holesky` to `hoodi` in the example commands.
* [`hardhat.config.hoodi-fork.ts`](diffhunk://#diff-ffabb78a7e8574ce8490692492db9abfb78965cf28ced6e308d00e91234b49dbL7-R17): Renamed from `hardhat.config.holesky-fork.ts` and updated the network configuration accordingly.
* [`src/networks.ts`](diffhunk://#diff-e382f55be3dc89bd924312a0cececc645810e0aa62b217d3969a61aff5337f93L4-R4): Changed the network name from `holesky` to `hoodi` in the type definition and RPC URL function. [[1]](diffhunk://#diff-e382f55be3dc89bd924312a0cececc645810e0aa62b217d3969a61aff5337f93L4-R4) [[2]](diffhunk://#diff-e382f55be3dc89bd924312a0cececc645810e0aa62b217d3969a61aff5337f93L16-R16)

### Dependency Updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10-R10): Updated PNPM version from `9.11.0` to `10.8.0`.

### Configuration Updates:
* `hardhat.config.mainnet-fork-shanghai.ts`, `hardhat.config.mainnet-fork.ts`, `hardhat.config.mainnet-scratch.ts`: Updated Solidity version from `0.8.23` to `0.8.25` and increased the account count from 10 to 30 in the network configurations. [[1]](diffhunk://#diff-f9f3a9ebcc8b876a1adc4303f4d088c22399cac1e7a811e658f88d3508cfcc73L7-R15) [[2]](diffhunk://#diff-e2b6abaa2981fa1ea084c76241eaf59a7b739fd3c1432d11b04e3714f445d1e3L7-R14) [[3]](diffhunk://#diff-2c17d0f1d2dfdde759ac169106d6c149d31a5680b03f0f2e3cb0aa385444cf61L7-R13)